### PR TITLE
add simplest implementation of create notebook

### DIFF
--- a/lib/everex/api/notebook.ex
+++ b/lib/everex/api/notebook.ex
@@ -1,0 +1,36 @@
+# 
+# Copyright 2015 Johan Wärlander
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+defmodule Everex.Api.Notebook do
+  alias Everex.NoteStore
+
+  # Sane defaults for required fields
+  @defaultNotebook false
+
+  defstruct name: nil, defaultNotebook: @defaultNotebook
+
+  def new(name) do
+    struct(__MODULE__, name: name)
+  end
+
+  def is_default(notebook, default) do
+    %{notebook | defaultNotebook: default}
+  end
+
+  def save(notebook, client) do
+    NoteStore.create_notebook(client, notebook)
+  end
+end
+

--- a/lib/everex/note_store.ex
+++ b/lib/everex/note_store.ex
@@ -68,14 +68,8 @@ defmodule Everex.NoteStore do
   @doc"""
   Creates a single notebook
   """
-  def create_notebook(client,
-                      name,
-                      default_notebook \\ false,
-                      stack \\ :undefined)
-  do
-    draft_notebook = %Types.Notebook{name: name, 
-                                     defaultNotebook: default_notebook,
-                                     stack: stack}
+  def create_notebook(client, notebook) do
+    draft_notebook = struct(Types.Notebook, Map.to_list(notebook))
     thrift_call(client, :notestore, :createNotebook, [draft_notebook])
   end
 end

--- a/lib/everex/note_store.ex
+++ b/lib/everex/note_store.ex
@@ -64,4 +64,18 @@ defmodule Everex.NoteStore do
         with_resources_alternate_data
     ])
   end
+
+  @doc"""
+  Creates a single notebook
+  """
+  def create_notebook(client,
+                      name,
+                      default_notebook \\ false,
+                      stack \\ :undefined)
+  do
+    draft_notebook = %Types.Notebook{name: name, 
+                                     defaultNotebook: default_notebook,
+                                     stack: stack}
+    thrift_call(client, :notestore, :createNotebook, [draft_notebook])
+  end
 end

--- a/test/everex_test.exs
+++ b/test/everex_test.exs
@@ -71,4 +71,10 @@ defmodule EverexTest do
       %Types.EDAMUserException{errorCode: 2, parameter: "Note.guid"}
     }
   end
+
+  test "create notebook" do
+    {:ok, client} = Client.new(@developer_token, sandbox: true)
+    {:ok, notebook} = NoteStore.create_notebook(client, "Elixir Notebook")
+    assert "Elixir Notebook" = notebook.name
+  end
 end

--- a/test/everex_test.exs
+++ b/test/everex_test.exs
@@ -19,6 +19,7 @@ defmodule EverexTest do
   alias Everex.Client
   alias Everex.NoteStore
   alias Everex.Types
+  alias Everex.Api.Notebook
 
   @developer_token System.get_env("EN_DEVELOPER_TOKEN")
 
@@ -74,7 +75,9 @@ defmodule EverexTest do
 
   test "create notebook" do
     {:ok, client} = Client.new(@developer_token, sandbox: true)
-    {:ok, notebook} = NoteStore.create_notebook(client, "Elixir Notebook")
-    assert "Elixir Notebook" = notebook.name
+    {:ok, notebook} = Notebook.new("SadBoys")
+                      |> Notebook.is_default(false)
+                      |> Notebook.save(client)
+    assert "SadBoys" = notebook.name
   end
 end


### PR DESCRIPTION
Like I mentioned in the commit message, this commit is more for discussion than anything. We need to consider arg passing conventions and perhaps Genserver factories wrapping the Evernote "primitive" types to handle creation, updates, destruction, and errors but even then we still need a convention for how args should be passed, specifically what type(s) to use